### PR TITLE
Add basic `build & test` GH actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: "Build & test"
+on: [pull_request]
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: NPM install
+      run: npm ci --force
+    - name: Unit tests
+      run: npm run test
+    - name: Build
+      run: npm run build


### PR DESCRIPTION
### What has been done
- Added basic integration with GH actions for building and testing the application
-- npm dependencies installation is used with `--force` flag due to existing issue https://github.com/facebook/create-react-app/pull/13071