### PR TITLE
Force colored console output for node commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: "Build & test"
 on: [pull_request]
+env:
+  FORCE_COLOR: 2
 jobs:
   build_and_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What has been done
- Forcing colored console output for node commands on GitHub Actions builds.

By default console output is not colored for node.js commands on GitHub Actions console. Need to force the colored output. https://nodejs.org/api/tty.html\#writestreamgetcolordepthenv

| default    | FORCE_COLOR = 2 |
| ----------- | ----------- |
| <img width="794" alt="image" src="https://user-images.githubusercontent.com/3036347/227499861-ed73a4a4-c4e0-416c-b724-ea8829284348.png"> | <img width="797" alt="image" src="https://user-images.githubusercontent.com/3036347/227499977-675f8a18-7617-4e95-a602-02353cd1a40f.png"> |
