### PR TITLE
Configure code coverage calculation and upload to Codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
           npm run lint
           npm run prettier
       - name: Unit tests
-        run: npm run test
+        run: npm run tests-with-coverage
       - name: Build
         run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,10 @@ jobs:
         run: npm run tests-with-coverage
       - name: Build
         run: npm run build
+      - name: Upload coverage (Codecov)
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/clover.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Description
 
-[![Build](https://github.com/vgaidarji/react-graphql-playground/actions/workflows/main.yml/badge.svg)](https://github.com/vgaidarji/react-graphql-playground/actions/workflows/main.yml)
+[![Build](https://github.com/vgaidarji/react-graphql-playground/actions/workflows/main.yml/badge.svg)](https://github.com/vgaidarji/react-graphql-playground/actions/workflows/main.yml) [![codecov](https://codecov.io/gh/vgaidarji/react-graphql-playground/branch/configure-code-coverage/graph/badge.svg?token=ORM7bMBo3n)](https://codecov.io/gh/vgaidarji/react-graphql-playground)
 
-Playground react app which uses graphql API to fetch different information. 
-For list of public graphql APIs available visit https://stepzen.com/blog/free-public-graphql-apis. 
+Playground react app which uses graphql API to fetch different information.
+For list of public graphql APIs available visit https://stepzen.com/blog/free-public-graphql-apis.
 
 - Countries API https://countries.trevorblades.com/graphql
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "tests-with-coverage": "FORCE_COLOR=2 CI=true npm run test -- --coverage",
     "eject": "react-scripts eject",
     "lint": "eslint src --ext .ts,.tsx",
     "prettier": "prettier --list-different \"**/*.{ts,tsx}\"",


### PR DESCRIPTION
### What has been done
1. Added script which runs tests and outputs coverage. 
  `CI=true` https://create-react-app.dev/docs/running-tests/#on-your-own-environment
    > By default npm test runs the watcher with interactive CLI. However, you can force it to run tests once and finish the process by setting an environment variable called CI.
2. Added step to upload coverage to `Codecov` https://app.codecov.io/. Added `CODECOV_TOKEN` secret on GitHub.

### How to test
1. Run `npm run tests-with-coverage` locally and make sure test coverage is printed
2. Run build on GitHub and confirm coverage is printed to console. Confirm coverage is uploaded to Codecov https://app.codecov.io/gh/vgaidarji/react-graphql-playground.
