### PR TITLE
Trigger GH actions build from main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: "Build & test"
-on: [pull_request]
+on: [push, pull_request]
 env:
   FORCE_COLOR: 2
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: "Build & test"
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 env:
   FORCE_COLOR: 2
 jobs:


### PR DESCRIPTION
### What has been done
1. Enabled GitHub actions builds from push triggers to enable builds from `main` branch as well.

### How to test
1. Merge and confirm builds are triggered from `main` branch
