### PR TITLE
Switch to local report from clover for Codecov coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/clover.xml
+          files: ./coverage/lcov.info
           fail_ci_if_error: true
           verbose: true
       - name: Deploy to Firebase (Pull Request)


### PR DESCRIPTION


### What has been done
1. Switched to `lcov` report from `clover` for Codecov coverage
	Codecov doesn't consider partial hits.	https://docs.codecov.com/docs/frequently-asked-questions#how-is-coverage-calculated 	
	Inspecting `coverage/lcov-report/index.html` the coverage is 100%, while `coverage/clover.xml` used by Codecov will show <100%. The partials, in this case, are `if (loading)` / `if (error)` conditionals on react components where I'm sure those are covered in tests.

### How to test
1. Make sure Codecov correctly consumes `lcov` coverage report and shows coverage information.
