### PR TITLE
Integrate weather fetching via OpenWeatherMap API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,40 +1,36 @@
 {
-    "root": true,
-    "env": {
-        "browser": true,
-        "node": true,
-        "es2021": true,
-        "jest": true
-    },
-    "settings": {
-        "react": {
-          "version": "detect"
-        }
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:react/recommended",
-        "prettier"
-    ],
-    "overrides": [
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "sourceType": "module",
-        "project": ["tsconfig.json"]
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint",
-        "prettier"
-    ],
-    "rules": {
-        "prettier/prettier" : ["error"],
-        "react/react-in-jsx-scope": "off"
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true,
+    "jest": true
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
     }
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "prettier"
+  ],
+  "overrides": [],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module",
+    "project": ["tsconfig.json"]
+  },
+  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "rules": {
+    "prettier/prettier": ["error"],
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off"
+  }
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           node-version: 19
           cache: "npm"
+      - name: Prepare env vars
+        run: |
+          touch .env
+          echo REACT_APP_OPENWEATHERMAP_API_KEY=${{ secrets.REACT_APP_OPENWEATHERMAP_API_KEY }} > .env
+          cat .env
       - name: NPM install
         run: npm ci --force
       - name: Lint
@@ -24,7 +29,7 @@ jobs:
       - name: Unit tests
         run: npm run tests-with-coverage
       - name: Build
-        run: npm run build
+        run: cat .env && npm run build
       - name: Upload coverage (Codecov)
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           touch .env
           echo REACT_APP_OPENWEATHERMAP_API_KEY=${{ secrets.REACT_APP_OPENWEATHERMAP_API_KEY }} > .env
-          cat .env
       - name: NPM install
         run: npm ci --force
       - name: Lint
@@ -29,7 +28,7 @@ jobs:
       - name: Unit tests
         run: npm run tests-with-coverage
       - name: Build
-        run: cat .env && npm run build
+        run: npm run build
       - name: Upload coverage (Codecov)
         uses: codecov/codecov-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 .env.test.local
 .env.production.local
 
+# config with env variables
+.env
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
       "!**/*.d.ts",
       "!src/index.tsx",
       "!src/reportWebVitals.ts",
-      "!src/components/countries/getCountries.tsx",
-      "!src/components/country/getCountry.tsx"
+      "!**/*GqlQuery.{ts,tsx}",
+      "!**/*GqlRequest.{ts,tsx}"
     ]
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,17 @@
 import * as React from "react";
 import Routing from "./routing/Routing";
 
-import { ApolloProvider, ApolloClient, InMemoryCache } from "@apollo/client";
+import { ApolloProvider, ApolloClient, ApolloLink, InMemoryCache, HttpLink } from "@apollo/client";
+import { ApiEndpoint, ApiClientName } from "./components/api/ApiEndpoint";
 
+const countriesLink = new HttpLink({ uri: ApiEndpoint.countries });
+const openWeatherMapLink = new HttpLink({ uri: ApiEndpoint.openWeatherMap });
 const client = new ApolloClient({
-  uri: "https://countries.trevorblades.com/graphql",
+  link: ApolloLink.split(
+    (operation) => operation.getContext().clientName === ApiClientName.countries,
+    countriesLink, // <= first match if clientName matches
+    openWeatherMapLink // <= fallback
+  ),
   cache: new InMemoryCache()
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,18 @@ import Routing from "./routing/Routing";
 import { ApolloProvider, ApolloClient, ApolloLink, InMemoryCache, HttpLink } from "@apollo/client";
 import { ApiEndpoint, ApiClientName } from "./components/api/ApiEndpoint";
 
-const countriesLink = new HttpLink({ uri: ApiEndpoint.countries });
-const openWeatherMapLink = new HttpLink({ uri: ApiEndpoint.openWeatherMap });
 const client = new ApolloClient({
-  link: ApolloLink.split(
-    (operation) => operation.getContext().clientName === ApiClientName.countries,
-    countriesLink, // <= first match if clientName matches
-    openWeatherMapLink // <= fallback
-  ),
+  link: createApolloLink(),
   cache: new InMemoryCache()
 });
+
+function createApolloLink() {
+  return ApolloLink.split(
+    (operation) => operation.getContext().clientName === ApiClientName.countries,
+    new HttpLink({ uri: ApiEndpoint.countries }), // <= first match if clientName matches
+    new HttpLink({ uri: ApiEndpoint.openWeatherMap }) // <= fallback
+  );
+}
 
 function App() {
   return (

--- a/src/components/api/ApiEndpoint.ts
+++ b/src/components/api/ApiEndpoint.ts
@@ -1,0 +1,15 @@
+export enum ApiEndpoint {
+  countries = "https://countries.trevorblades.com/graphql",
+  openWeatherMap = "https://public2129e7bae524fdad.stepzen.net/api/openweathermap/__graphql"
+}
+
+/**
+ * Used to choose from list of APIs API client needed to perform given operations.
+ * Apollo API client doesn't support multiple endpoints by default,
+ * so this achieved via supply of different HttpLink's based on clientName passed
+ * through useQuery apollo react hook context parameter.
+ */
+export enum ApiClientName {
+  countries = "countries-api",
+  openWeatherMap = "openweathermap-api"
+}

--- a/src/components/countries/CountriesList.test.tsx
+++ b/src/components/countries/CountriesList.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
 import CountriesList from "./CountriesList";
-import { getCountries } from "./getCountries";
+import { getCountries } from "./getCountriesGqlRequest";
 import { Countries } from "../../types/Countries";
 import { ApolloError } from "@apollo/client/errors";
 
@@ -13,7 +13,7 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate
 }));
 
-jest.mock("../countries/getCountries");
+jest.mock("../countries/getCountriesGqlRequest");
 const mockedGetCountries = getCountries as jest.MockedFunction<typeof getCountries>;
 
 describe("CountriesList", () => {

--- a/src/components/countries/CountriesList.tsx
+++ b/src/components/countries/CountriesList.tsx
@@ -9,7 +9,7 @@ import Paper from "@mui/material/Paper";
 import { useNavigate } from "react-router-dom";
 
 import { Country } from "../../types/Country";
-import { getCountries } from "./getCountries";
+import { getCountries } from "./getCountriesGqlRequest";
 
 const CountriesList: React.FC = () => {
   const navigate = useNavigate();

--- a/src/components/countries/getCountriesGqlRequest.ts
+++ b/src/components/countries/getCountriesGqlRequest.ts
@@ -2,8 +2,11 @@ import { Countries } from "../../types/Countries";
 import { GET_COUNTRIES } from "./countriesGqlQuery";
 import { useQuery } from "@apollo/react-hooks";
 import { ApolloError } from "@apollo/client/errors";
+import { ApiClientName } from "../api/ApiEndpoint";
 
 export function getCountries(): [boolean, ApolloError | undefined, Countries] {
-  const { loading, error, data } = useQuery<Countries>(GET_COUNTRIES);
+  const { loading, error, data } = useQuery<Countries>(GET_COUNTRIES, {
+    context: { clientName: ApiClientName.countries }
+  });
   return [loading, error, data as Countries];
 }

--- a/src/components/country/CountryComponent.test.tsx
+++ b/src/components/country/CountryComponent.test.tsx
@@ -2,12 +2,14 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import CountryComponent from "./CountryComponent";
-import { getCountry } from "./getCountry";
+import { getCountry } from "./getCountryGqlRequest";
 import { ApolloError } from "@apollo/client";
 import { Country } from "../../types/Country";
 
-jest.mock("../country/getCountry");
+jest.mock("../country/getCountryGqlRequest");
 const mockedGetCountry = getCountry as jest.MockedFunction<typeof getCountry>;
+
+jest.mock("../weather/WeatherInfo");
 
 describe("country component", () => {
   it("should render loading state", async () => {

--- a/src/components/country/CountryComponent.tsx
+++ b/src/components/country/CountryComponent.tsx
@@ -2,8 +2,9 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import { useLocation } from "react-router-dom";
-import { getCountry } from "./getCountry";
+import { getCountry } from "./getCountryGqlRequest";
 import Container from "@mui/material/Container";
+import WeatherInfo from "../weather/WeatherInfo";
 
 const CountryComponent: React.FC = () => {
   const countryParam = useLocation().state?.country;
@@ -15,16 +16,15 @@ const CountryComponent: React.FC = () => {
   console.log(country);
 
   return (
-    <Container maxWidth="sm" sx={{ marginTop: 10 }}>
+    <Container maxWidth="xs" sx={{ marginTop: 5 }}>
       <Card variant="outlined">
         <CardContent>
-          <Typography variant="h5" component="div">
+          <Typography variant="h5" component="div" align="center">
             {country.name} {country.emoji}
           </Typography>
-          <Typography sx={{ mb: 1.5 }} color="text.secondary">
-            {country.capital}
+          <Typography sx={{ mb: 1.5 }} color="text.secondary" align="center">
+            {country.capital}, <WeatherInfo countryCapital={countryParam.capital} />
           </Typography>
-          <Typography variant="body2"></Typography>
         </CardContent>
       </Card>
     </Container>

--- a/src/components/country/getCountryGqlRequest.ts
+++ b/src/components/country/getCountryGqlRequest.ts
@@ -2,10 +2,12 @@ import { Country } from "../../types/Country";
 import { GET_COUNTRY } from "./countryGqlQuery";
 import { useQuery } from "@apollo/react-hooks";
 import { ApolloError } from "@apollo/client/errors";
+import { ApiClientName } from "../api/ApiEndpoint";
 
 export function getCountry(countryCode: string): [boolean, ApolloError | undefined, Country] {
   const { loading, error, data } = useQuery(GET_COUNTRY, {
-    variables: { countryCode: countryCode }
+    variables: { countryCode: countryCode },
+    context: { clientName: ApiClientName.countries }
   });
   return [loading, error, data?.country as Country];
 }

--- a/src/components/weather/WeatherInfo.test.tsx
+++ b/src/components/weather/WeatherInfo.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ApolloError } from "@apollo/client";
+import { getWeatherForCountry } from "./getWeatherForCountryGqlRequest";
+import { Weather } from "../../types/Weather";
+import WeatherInfo from "./WeatherInfo";
+
+jest.mock("./getWeatherForCountryGqlRequest");
+const mockedGetWeatherForCountry = getWeatherForCountry as jest.MockedFunction<
+  typeof getWeatherForCountry
+>;
+
+describe("weather info component", () => {
+  it("should render loading state", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedGetWeatherForCountry.mockReturnValueOnce([true, null as any, {} as Weather]);
+
+    render(
+      <MemoryRouter>
+        <WeatherInfo countryCapital={""} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/loading weather.../i)).toBeInTheDocument();
+  });
+
+  it("should render error state", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedGetWeatherForCountry.mockReturnValueOnce([
+      false,
+      new ApolloError({ errorMessage: "" }),
+      {} as Weather
+    ]);
+
+    render(
+      <MemoryRouter>
+        <WeatherInfo countryCapital={""} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/no weather info./i)).toBeInTheDocument();
+  });
+
+  it("should render weather info", async () => {
+    const weather: Weather = {
+      wind: {
+        speed: 0,
+        deg: 0
+      },
+      name: "",
+      main: {
+        feels_like: 0,
+        humidity: 0,
+        pressure: 0,
+        temp: 33,
+        temp_max: 0,
+        temp_min: 0
+      },
+      weather: [
+        {
+          main: "clear sky",
+          description: "",
+          icon: ""
+        }
+      ]
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedGetWeatherForCountry.mockReturnValueOnce([false, null as any, weather]);
+
+    render(
+      <MemoryRouter>
+        <WeatherInfo countryCapital={"MD"} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/33/i)).toBeInTheDocument();
+    expect(await screen.findByText(/clear sky/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/weather/WeatherInfo.tsx
+++ b/src/components/weather/WeatherInfo.tsx
@@ -1,0 +1,21 @@
+import { getWeatherForCountry } from "./getWeatherForCountryGqlRequest";
+
+const WeatherInfo: React.FC<{ countryCapital: string }> = ({ countryCapital }) => {
+  const [loading, error, weather] = getWeatherForCountry(countryCapital);
+
+  if (loading) return <>loading weather...</>;
+  if (error)
+    return (
+      <>
+        <i>no weather info.</i>
+      </>
+    );
+
+  return (
+    <>
+      {weather.main.temp} ({weather.weather[0].main}){" "}
+    </>
+  );
+};
+
+export default WeatherInfo;

--- a/src/components/weather/getWeatherForCountryGqlRequest.ts
+++ b/src/components/weather/getWeatherForCountryGqlRequest.ts
@@ -1,0 +1,20 @@
+import { Weather } from "../../types/Weather";
+import { useQuery } from "@apollo/react-hooks";
+import { ApolloError } from "@apollo/client/errors";
+import { GET_WEATHER_FOR_COUNTRY } from "./weatherForCountryGqlQuery";
+import { ApiClientName } from "../api/ApiEndpoint";
+
+export function getWeatherForCountry(
+  countryName: string
+): [boolean, ApolloError | undefined, Weather] {
+  const { loading, error, data } = useQuery(GET_WEATHER_FOR_COUNTRY, {
+    variables: {
+      // REACT_APP_OPENWEATHERMAP_API_KEY comes from .env
+      appId: process.env.REACT_APP_OPENWEATHERMAP_API_KEY,
+      q: countryName,
+      units: "metric"
+    },
+    context: { clientName: ApiClientName.openWeatherMap }
+  });
+  return [loading, error, data?.weather as Weather];
+}

--- a/src/components/weather/getWeatherForCountryGqlRequest.ts
+++ b/src/components/weather/getWeatherForCountryGqlRequest.ts
@@ -7,7 +7,6 @@ import { ApiClientName } from "../api/ApiEndpoint";
 export function getWeatherForCountry(
   countryName: string
 ): [boolean, ApolloError | undefined, Weather] {
-  console.log(process.env.REACT_APP_OPENWEATHERMAP_API_KEY);
   const { loading, error, data } = useQuery(GET_WEATHER_FOR_COUNTRY, {
     variables: {
       // REACT_APP_OPENWEATHERMAP_API_KEY comes from .env

--- a/src/components/weather/getWeatherForCountryGqlRequest.ts
+++ b/src/components/weather/getWeatherForCountryGqlRequest.ts
@@ -7,6 +7,7 @@ import { ApiClientName } from "../api/ApiEndpoint";
 export function getWeatherForCountry(
   countryName: string
 ): [boolean, ApolloError | undefined, Weather] {
+  console.log(process.env.REACT_APP_OPENWEATHERMAP_API_KEY);
   const { loading, error, data } = useQuery(GET_WEATHER_FOR_COUNTRY, {
     variables: {
       // REACT_APP_OPENWEATHERMAP_API_KEY comes from .env

--- a/src/components/weather/weatherForCountryGqlQuery.ts
+++ b/src/components/weather/weatherForCountryGqlQuery.ts
@@ -1,0 +1,48 @@
+import gql from "graphql-tag";
+
+// https://dashboard.stepzen.com/explorer?endpoint=https://public2129e7bae524fdad.stepzen.net/api/openweathermap/__graphql
+export const GET_WEATHER_FOR_COUNTRY = gql`
+  query GetWeatherForCountry($appId: String, $q: String, $units: String) {
+    weather: openweathermapQuery(appid: $appId, q: $q, units: $units) {
+      base
+      clouds {
+        all
+      }
+      cod
+      coord {
+        lat
+        lon
+      }
+      dt
+      id
+      main {
+        feels_like
+        humidity
+        pressure
+        temp
+        temp_max
+        temp_min
+      }
+      name
+      sys {
+        country
+        id
+        sunrise
+        sunset
+        type
+      }
+      timezone
+      visibility
+      weather {
+        description
+        icon
+        id
+        main
+      }
+      wind {
+        deg
+        speed
+      }
+    }
+  }
+`;

--- a/src/types/Weather.ts
+++ b/src/types/Weather.ts
@@ -1,0 +1,30 @@
+export interface Main {
+  feels_like: number;
+  humidity: number;
+  pressure: number;
+  temp: number;
+  temp_max: number;
+  temp_min: number;
+}
+
+export interface Wind {
+  speed: number;
+  deg: number;
+}
+
+export interface IWeather {
+  main: string;
+  description: string;
+  icon: string;
+}
+
+export interface Weather {
+  main: Main;
+  weather: IWeather[];
+  wind: Wind;
+  name: string;
+}
+
+export interface OpenWeatherWeatherResponse {
+  weather: Weather;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,7 +15,5 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
### What has been done
1. Integrated weather fetching via OpenWeatherMap API.
2. Added multiple GraphQL endpoints switch based on the operation parameter `clientName` passed via `context` when executing a query. Credits https://www.jamalx31.com/tech-posts/using-apollo-with-multiple-graphql-endpoints
3. Passing test OpenWeatherMap API key via `REACT_APP_OPENWEATHERMAP_API_KEY` env variable. Not the safest way as key ends up being bundled in final js, but good enough for this test project.

### How to test
1. Deploy the application and navigate to any country page. Confirm weather information is fetched and is shown to the right of the country capital name.

<table>
<tr>
<th> Before</th>
<th> After</th>
</tr>
<tr>
	<td>
<img width="559" alt="image" src="https://user-images.githubusercontent.com/3036347/229495872-326f8af2-dd48-40a7-8686-703f62eb275c.png">
	</td>
	<td>
	<img width="401" alt="image" src="https://user-images.githubusercontent.com/3036347/229465012-ebb21ca4-bf7b-4027-90d2-0017489a7b7a.png">
	</td>
</table>





